### PR TITLE
Resolved bento warnings

### DIFF
--- a/measure
+++ b/measure
@@ -3,6 +3,7 @@
 from measure import Measure, ST_FAILED
 
 import os
+import sys
 import time
 import wavefront_api_client
 import yaml
@@ -271,7 +272,7 @@ class WaveFront(Measure):
 
         try:
             f = open(CFG_FILE)
-            d = yaml.load(f)
+            d = yaml.safe_load(f)
         except IOError as e:
             raise Exception(
                 "cannot read configuration from {}:{}".format(CFG_FILE, e.strerror))


### PR DESCRIPTION
Bento Output:

```
flake8 undefined-name https://lintlyci.github.io/Flake8Rules/rules/F821.html          
     > measure:63                                                                     
     ╷                                                                                
   63│   sys.exit(3)                                                                  
     ╵                                                                                
     = undefined name 'sys'

bandit yaml-load https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html
     > measure:274
     ╷
  274│   d = yaml.load(f)
     ╵
     = Use of unsafe yaml load. Allows instantiation of arbitrary objects.
       Consider yaml.safe_load().
```